### PR TITLE
Ignore changes to ipset

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,12 @@
 
 resource "aws_wafregional_ipset" "ips" {
   name = "waf-app-${var.environment}-ips"
+
+  lifecycle {
+    ignore_changes = [
+      "ip_set_descriptor",
+    ]
+  }
 }
 
 resource "aws_wafregional_rule" "ips" {


### PR DESCRIPTION
In terraform 0.11.x, we can't use a dynamic block yet, so IP addresses must be added to the ipset outside of terraform.  This PR ignores those changes, so terraform doesn't plan to remove the IP addresses.