### PR TITLE
Remove stale variable and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Creates the following resources:
 
 * Web Application Firewall (WAF)
 * Links F5-managed OWASP rules for WAF to block common attacks
-* Creates rule for WAF to block requests by source IP Address
+* Creates rule for WAF to block requests by source IP Address (**Note**: the list of blocked IPs are not managed by this module)
 * Creates rule for WAF to block requests by path (as found in URI)
 * Creates rule for WAF to allow requests by host (as found in HTTP Header)
 * Attaches WAF to Application Load Balancer (ALB)
@@ -35,7 +35,6 @@ module "waf" {
 | associate\_alb | Whether to associate an Application Load Balancer (ALB) with an Web Application Firewall (WAF) Access Control List (ACL). | string | `"false"` | no |
 | environment | Name of the environment to create (e.g., staging, prod, etc.). | string | n/a | yes |
 | ip\_rate\_limit | The rate limit for IPs matching with a 5 minute window. | string | `"2000"` | no |
-| ips\_disallow | The list of IP addresses to block using the WAF. | list | `[]` | no |
 | regex\_host\_allow\_pattern\_strings | The list of hosts to allow using the WAF (as found in HTTP Header). | list | n/a | yes |
 | regex\_path\_disallow\_pattern\_strings | The list of URI paths to block using the WAF. | list | n/a | yes |
 | wafregional\_rule\_f5\_id | The ID of the F5 Rule Group to use for the WAF for the ALB.  Find the id with "aws waf-regional list-subscribed-rule-groups". | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@
  *
  * * Web Application Firewall (WAF)
  * * Links F5-managed OWASP rules for WAF to block common attacks
- * * Creates rule for WAF to block requests by source IP Address
+ * * Creates rule for WAF to block requests by source IP Address (**Note**: the list of blocked IPs are not managed by this module)
  * * Creates rule for WAF to block requests by path (as found in URI)
  * * Creates rule for WAF to allow requests by host (as found in HTTP Header)
  * * Attaches WAF to Application Load Balancer (ALB)

--- a/variables.tf
+++ b/variables.tf
@@ -29,12 +29,6 @@ variable "regex_host_allow_pattern_strings" {
   type        = "list"
 }
 
-variable "ips_disallow" {
-  description = "The list of IP addresses to block using the WAF."
-  type        = "list"
-  default     = []
-}
-
 variable "ip_rate_limit" {
   description = "The rate limit for IPs matching with a 5 minute window."
   type        = "string"


### PR DESCRIPTION
Removes reference to `ips_disallow` to address https://github.com/trussworks/terraform-aws-waf/issues/7 .