### PR TITLE
deprecate older terraform versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
-    hooks:
-      - id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md", "."]
-
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ Creates the following resources:
 - Creates rule for WAF to allow requests by host (as found in HTTP Header)
 - Attaches WAF to Application Load Balancer (ALB)
 
-## Terraform Versions
-
-Terraform 0.13 and newer. Pin module version to ~> 3.X. Submit pull-requests to master branch.
-
-Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to terraform012 branch.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ module "waf" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 1.0 |
 | aws | >= 3.0 |
 
 ## Providers

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = ">= 3.0"


### PR DESCRIPTION
-   Modified README
-   Set expected terraform version to be equal or greater than Terraform version 1.0
